### PR TITLE
Update gradle, pull dragon survival jar from cursemaven to allow for portable build

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@ This is currently built against MC 1.20.1; I'll entertain porting it if the
 modpack I play ever does so (it shouldn't be hard, though I think DS changed
 their age system, so...).
 
-**Important:** Before using `./gradlew build`, this project expects that you
-put `dragonsurvival-1.20.1-13.04.2025-all.jar` (_this exact version_) of Dragon
-Survival into a directory called `libs`. I'm not shipping that artifact because
-it's large. Your luck may vary with other versions, and you'll have to update
-`build.gradle` accordingly. You've been warned.
-
 **Note:** `./gradlew runClient` doesn't work yet because I'm too lazy to figure
 out proper dev dependencies for DS and GeckoLib. You'll just have to `./gradlew
 build` and use the finished `jar` in a modpack proper; that's what I'm doing,

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,17 @@ group = mod_group_id
 repositories {
     mavenLocal()
     flatDir {
-    	dirs "libs"
+        dirs "libs"
+    }
+    exclusiveContent {
+        forRepository {
+            maven {
+                url "https://cursemaven.com"
+            }
+        }
+        filter {
+            includeGroup "curse.maven"
+        }
     }
 }
 
@@ -144,7 +154,7 @@ dependencies {
     // For more info:
     // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
-    modCompileOnly "blank:dragonsurvival-1.20.1:13.04.2025-all"
+    modImplementation "curse.maven:dragon-survival-420799:6420793"
 }
 
 // Uncomment the lines below if you wish to configure mixin. The mixin file should be named modid.mixins.json.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -86,8 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
-' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.9.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.10.0'
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,17 @@
+# shell.nix
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.jdk17
+    pkgs.jdk21
+  ];
+
+  shellHook = ''
+    export JAVA_17_HOME="${pkgs.jdk17.home}"
+    export JAVA_21_HOME="${pkgs.jdk21.home}"
+    export JAVA_HOME="${pkgs.jdk21.home}"
+
+    alias gradle="./gradlew -Porg.gradle.java.installations.fromEnv=JAVA_17_HOME,JAVA_21_HOME"
+  '';
+}


### PR DESCRIPTION
Ask in your README and you shall receive.

In addition, this adds a `shell.nix` file to allow for compilation on NixOS systems due to the requirements of 2 different JDK versions simultaneously.